### PR TITLE
Update fetch 

### DIFF
--- a/src/app/patient/page.tsx
+++ b/src/app/patient/page.tsx
@@ -74,7 +74,7 @@ const Page = () => {
       );
       if (response.ok) {
         setErrorMessage("");
-        const data = await response.json();
+        const data = await response.json().then((res) => res.results);
         data.sort((a: Patient, b: Patient) => {
           return b._metadata.lastUpdatedAt - a._metadata.lastUpdatedAt;
         });


### PR DESCRIPTION
Quick fix. It now accesses the array from `response.results` instead of just the response object